### PR TITLE
Make `run.py --auto-update` respect chosen version

### DIFF
--- a/Update AMI.sh
+++ b/Update AMI.sh
@@ -8,6 +8,7 @@ ENV=@option.Environment@
 VERSION=@option.Version@
 LAUNCH_CONFIGURATION_NAME="m5-reserved-instances-launch-config-${DATE}"
 KOBO_INSTALL_DIR="/home/ubuntu/kobo-install/"
+KOBO_INSTALL_VERSION="$VERSION"
 
 
 echo DATE : $DATE


### PR DESCRIPTION
I'm going to manually paste this change into the Rundeck job and see if it works :cowboy_hat_face: